### PR TITLE
Explicitly mandate root privileges, ensure build exists and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,23 @@ Scripts to build custom bootstrap images using bdebstrap for TI platforms
 ## Directory Structure
 
 ```bash
-ti-bdebstrap
 ├── build.sh
+├── builds.toml
+├── configs
+│   ├── bdebstrap_configs
+│   │   ├── bookworm-default.yaml
+│   │   └── bullseye-default.yaml
+│   ├── bsp_sources.toml
+│   └── machines.toml
+├── LICENSE
+├── README.md
 ├── scripts
 │   ├── build_bsp.sh
+│   ├── build_distro.sh
 │   ├── common.sh
-│   ├── read-config.py
 │   └── setup.sh
-├── configs
-│   └── debian-bullseye.yaml
-├── machines.ini
-├── README.md
-└── LICENSE
+├── target
+│   └── files for target configs
 ```
 
 ## Prerequisites
@@ -41,30 +46,32 @@ pip3 install toml-cli
 
 ## Usage
 
-Note: The build script has to be run as root user
+A **build** (specified in `builds.toml` file) represents the image for a
+particular machine, BSP version and distribution variant. The `builds.toml`
+file contains a list of builds, with corresponding machine, BSP version and
+distribution variant specifications.
 
-To build all distros for all supported machines, run
+Further, each machine is defined in `configs/machines.toml`. Each BSP version is
+defined in `configs/bsp_sources.toml`. Each distribution variant is defined in
+the `configs/bdebstrap_configs/` directory.
 
-```bash
-host$ ./build.sh
-```
+Running these scripts requires root privileges.
 
-To build for a single machine, run
-
-```bash
-host$ ./build.sh <machine>
-```
-
-The output will be generated at `build/`
-
-For ex:
-
-To build for am62xx-evm
+##### General Syntax:
 
 ```bash
-host$ ./build.sh am62xx-evm
-
+sudo ./build.sh <build>
 ```
 
-and the output will be generated in ${topdir}/build
+Each successful build is placed in `build/` directory. Logs for each build are
+placed in the `logs/` directory.
 
+For example, the following command builds a Bookworm Debian image for am62xx-evm
+machine, where the BSP version is 09.00.00.005.
+
+```bash
+sudo ./build.sh am62x_bookworm_09.00.00.005
+```
+
+The output will be generated at `build/`. The log file will be
+`logs/am62x_bookworm_09.00.00.005.log`.

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,8 @@ do
     echo "${build}"
     setup_log_file "${build}"
 
+    validate_section "Build" ${build} "${topdir}/builds.toml"
+
     machine=($(read_build_config ${build} machine))
     bsp_version=($(read_build_config ${build} bsp_version))
     distro_variant=($(read_build_config ${build} distro_variant))
@@ -45,6 +47,8 @@ do
     echo "machine: ${machine}"
     echo "bsp_version: ${bsp_version}"
     echo "distro_variant: ${distro_variant}"
+
+    validate_build ${machine} ${bsp_version} ${distro_variant}
 
     generate_rootfs ${build} ${machine} ${distro_variant}
     build_bsp ${build} ${machine} ${bsp_version}

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,12 @@ source ${topdir}/scripts/common.sh
 source ${topdir}/scripts/build_bsp.sh
 source ${topdir}/scripts/build_distro.sh
 
+if [ "$EUID" -ne 0 ] ; then
+    echo "Failed to run: requires root privileges"
+    echo "Exiting"
+    exit 1
+fi
+
 # exit if no arguments are passed
 if [ "$#" -ne 0 ]; then
     builds="$@"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,6 +36,31 @@ config=$2
     read_config ${topdir}/builds.toml $build $config
 }
 
+function validate_section() {
+section_type=$1
+section=$2
+config=$3
+
+    if  ! grep -q -x "\[$section\]" ${config}  ; then
+        log "${section_type} \"${section}\" does not exist. Exiting."
+        exit 1
+    fi
+}
+
+function validate_build() {
+machine=$1
+bsp_version=$2
+distro_variant=$3
+
+    validate_section "Machine" ${machine} "${topdir}/configs/machines.toml"
+    validate_section "BSP Version" ${bsp_version} "${topdir}/configs/bsp_sources.toml"
+
+    if [ ! -f "${topdir}/configs/bdebstrap_configs/${distro_variant}.yaml" ] ; then
+        log "Distro Variant \"${distro_variant}\" does not exist. Exiting."
+        exit 1
+    fi
+}
+
 function log() {
     command echo "$@"
     command echo "$@" >> "$LOG_FILE"


### PR DESCRIPTION
1. Exit the program if the user is not running the script with root privileges, with an error message.
2. Ensure the validity of the build provided. The build, and its machine, BSP version and distro variant should all exist in their respective files. If a build fails, the scripts stop (even if there were multiple builds)
3. Update readme to cover everything that has changed on the dev branch 