### PR TITLE
Add debs to be installed during image build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,9 +42,6 @@ do
 
     generate_rootfs ${build} ${machine} ${distro_variant}
     build_bsp ${build} ${machine} ${bsp_version}
-    # FIXME: Kernel and IMG rogue driver should be .deb packages
-    build_kernel ${machine} ${ROOTFS_DIR}
-    build_ti_img_rogue_driver ${machine} ${ROOTFS_DIR} ${KERNEL_DIR}
     package_and_clean ${build}
 
 done

--- a/builds.toml
+++ b/builds.toml
@@ -3,6 +3,7 @@
 builds = [
     "am62x_bookworm_09.00.00.005",
     "am62x_bullseye_09.00.00.005",
+    "am64x_bookworm_09.00.00.005",
 ]
 
 [am62x_bookworm_09.00.00.005]
@@ -15,3 +16,7 @@ builds = [
     bsp_version = "09.00.00.005"
     distro_variant = "bullseye-default"
 
+[am64x_bookworm_09.00.00.005]
+    machine = "am64xx-evm"
+    bsp_version = "09.00.00.005"
+    distro_variant = "bookworm-am64x"

--- a/configs/bdebstrap_configs/bookworm-am64x.yaml
+++ b/configs/bdebstrap_configs/bookworm-am64x.yaml
@@ -1,0 +1,58 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/ti-debpkgs.gpg
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  variant: standard
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - libti-rpmsg-char-dev
+    - libti-rpmsg-char
+    - linux-headers-6.1.33-dirty
+    - linux-image-6.1.33-dirty
+    - linux-libc-dev
+    - wl18xx-ti-utils
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/usr/share/keyrings'
+    - 'curl -s --compressed https://texasinstruments.github.io/ti-debpkgs/KEY.gpg | gpg --dearmor | tee $1/usr/share/keyrings/ti-debpkgs.gpg > /dev/null'
+    - 'echo "deb [signed-by=/usr/share/keyrings/ti-debpkgs.gpg] https://texasinstruments.github.io/ti-debpkgs/ ./" > $1/etc/apt/sources.list.d/ti-debpkgs.list'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for weston user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chown -R man: $1/var/cache/man/'
+    - 'chown -R man: $1/var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+

--- a/configs/bdebstrap_configs/bookworm-default.yaml
+++ b/configs/bdebstrap_configs/bookworm-default.yaml
@@ -81,9 +81,4 @@ mmdebstrap:
     - 'chroot "$1" apt-get update'
       # Setup .bashrc for clean command-line experience
     - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
-      # Weston Service and Config Files
-    - 'copy-in target/weston/weston.service /etc/systemd/system/'
-    - 'copy-in target/weston/weston.socket /etc/systemd/system/'
-    - 'copy-in target/weston/weston /etc/default/'
-    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
 

--- a/configs/bdebstrap_configs/bookworm-default.yaml
+++ b/configs/bdebstrap_configs/bookworm-default.yaml
@@ -31,6 +31,36 @@ mmdebstrap:
     - vim
     - k3conf
     - weston
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa-dev
+    - libegl1-mesa
+    - libgbm-dev
+    - libgbm1
+    - libgl1-mesa-dev
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa-dev
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6-dev
+    - libosmesa6
+    - libpowervr-gl-am62x
+    - libti-rpmsg-char-dev
+    - libti-rpmsg-char
+    - libwayland-egl1-mesa
+    - linux-headers-6.1.33-dirty
+    - linux-image-6.1.33-dirty
+    - linux-libc-dev
+    - mesa-common-dev
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - ti-img-rogue-driver-dkms
+    - wl18xx-ti-utils
   mirrors:
     - http://deb.debian.org/debian
   setup-hooks:

--- a/configs/machines.toml
+++ b/configs/machines.toml
@@ -10,3 +10,14 @@
     dmfw_machine = "am62xx"
     uboot_r5_defconfig = "am62x_evm_r5_defconfig"
     uboot_a53_defconfig = "am62x_evm_a53_defconfig"
+
+[am64xx-evm]
+    # device config
+    hostname = "am64xx"
+    # u-boot config
+    atf_target_board = "lite"
+    optee_platform = "k3-am64x"
+    sysfw_soc = "am64x"
+    dmfw_machine = "am64xx"
+    uboot_r5_defconfig = "am64x_evm_r5_defconfig"
+    uboot_a53_defconfig = "am64x_evm_a53_defconfig"

--- a/configs/machines.toml
+++ b/configs/machines.toml
@@ -10,7 +10,3 @@
     dmfw_machine = "am62xx"
     uboot_r5_defconfig = "am62x_evm_r5_defconfig"
     uboot_a53_defconfig = "am62x_evm_a53_defconfig"
-    # gpu driver config
-    pvr_target = "am62_linux"
-    pvr_window_system = "wayland"
-

--- a/scripts/build_distro.sh
+++ b/scripts/build_distro.sh
@@ -18,6 +18,22 @@ distro=$3
     cd ${topdir}/build/
 
     ROOTFS_DIR=${topdir}/build/${build}/tisdk-${distro}-${machine}-rootfs
+
+    setup_target_configs ${ROOTFS_DIR}
+}
+
+function setup_target_configs() {
+ROOTFS_DIR=$1
+
+    case ${machine} in
+        "am62xx-evm")
+            cp "${topdir}/target/weston/weston.service" "${ROOTFS_DIR}/etc/systemd/system/"
+            cp "${topdir}/target/weston/weston.socket" "${ROOTFS_DIR}/etc/systemd/system/"
+            cp "${topdir}/target/weston/weston" "${ROOTFS_DIR}/etc/default/"
+            mkdir -p "${ROOTFS_DIR}/etc/systemd/multi-user.target.wants/"
+            ln -s "/etc/systemd/system/weston.service" "${ROOTFS_DIR}/etc/systemd/multi-user.target.wants/weston.service"
+            ;;
+    esac
 }
 
 function package_and_clean() {


### PR DESCRIPTION
Some packages, like graphics drivers and TI SDKs, should be present in the image by default. Add them to the list to be installed directly during the build.