### PR TITLE
62* bdebstrap_configs: Add new packages

### DIFF
--- a/configs/bdebstrap_configs/am62-bookworm.yaml
+++ b/configs/bdebstrap_configs/am62-bookworm.yaml
@@ -32,6 +32,11 @@ mmdebstrap:
     - weston
     - alsa-utils
     - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
     - linux-image-6.1.46-k3
     - linux-headers-6.1.46-k3
     - linux-libc-dev

--- a/configs/bdebstrap_configs/am62p-bookworm.yaml
+++ b/configs/bdebstrap_configs/am62p-bookworm.yaml
@@ -32,6 +32,11 @@ mmdebstrap:
     - weston
     - alsa-utils
     - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
     - linux-image-6.1.46-k3
     - linux-headers-6.1.46-k3
     - linux-libc-dev

--- a/configs/bdebstrap_configs/am62sip-bookworm.yaml
+++ b/configs/bdebstrap_configs/am62sip-bookworm.yaml
@@ -32,6 +32,11 @@ mmdebstrap:
     - weston
     - alsa-utils
     - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
     - linux-image-6.1.46-k3
     - linux-headers-6.1.46-k3
     - linux-libc-dev


### PR DESCRIPTION
- Include gstreamer so that camera, videoplayback can be tested
- Include i2c-tools which is required on am62 platforms to enable touch on microtips lvds panel