### PR TITLE
build_bsp: Copy splash screen logo file to boot partition

### DIFF
--- a/scripts/build_bsp.sh
+++ b/scripts/build_bsp.sh
@@ -143,4 +143,11 @@ machine=$1
     make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} BL31=${TFA_DIR}/build/k3/lite/release/bl31.bin TEE=${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin O=${UBOOT_DIR}/out/a53 BINMAN_INDIRS=${topdir}/build/${build}/bsp_sources/ti-linux-firmware &>>"${LOG_FILE}"
     cp ${UBOOT_DIR}/out/a53/tispl.bin ${topdir}/build/${build}/tisdk-${distro}-${machine}-boot/ &>> ${LOG_FILE}
     cp ${UBOOT_DIR}/out/a53/u-boot.img ${topdir}/build/${build}/tisdk-${distro}-${machine}-boot/ &>> ${LOG_FILE}
+
+	case ${machine} in
+		am62pxx-evm | am62xx-evm | am62xx-lp-evm | am62xxsip-evm)
+			cp ${UBOOT_DIR}/tools/logos/ti_logo_414x97_32bpp.bmp.gz ${topdir}/build/${build}/tisdk-${distro}-${machine}-boot/ &>> ${LOG_FILE}
+			;;
+	esac
 }
+


### PR DESCRIPTION
U-Boot fails to boot without the logo file being present in the boot partition. So copy it there.