### PR TITLE
Add support for building debian trixie with 10.00 BSPs

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,6 +59,7 @@ jobs:
               gpg curl
           sudo apt install --fix-broken
           sudo pip3 install toml-cli
+          sudo pip3 install yamllint
           curl -s --compressed https://texasinstruments.github.io/ti-debpkgs/KEY.gpg | \
               gpg --dearmor | \
               sudo tee /usr/share/keyrings/ti-debpkgs.gpg > /dev/null

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ sudo apt install -y \
         python3-yaml python3-jsonschema python3-cryptography
 sudo apt install --fix-broken
 sudo pip3 install toml-cli
+sudo pip3 install yamllint
 ```
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -38,8 +38,16 @@ do
     validate_section "Build" ${build} "${topdir}/builds.toml"
 
     machine=($(read_build_config ${build} machine))
-    bsp_version=($(read_build_config ${build} bsp_version))
-    distro_variant=($(read_build_config ${build} distro_variant))
+    distro_codename=($(read_build_config ${build} distro_codename))
+    rt_linux=($(read_build_config ${build} rt_linux))
+
+    if [ ${rt_linux} == "true" ]; then
+        distro=${distro_codename}-rt-${machine}
+    else
+        distro=${distro_codename}-${machine}
+    fi
+
+    bsp_version=($(read_bsp_config ${distro_codename} bsp_version))
 
     export host_arch=`uname -m`
     export native_build=false
@@ -51,18 +59,18 @@ do
 
     echo "machine: ${machine}"
     echo "bsp_version: ${bsp_version}"
-    echo "distro_variant: ${distro_variant}"
+    echo "distro: ${distro}"
     echo "host_arch: ${host_arch}"
 
     setup_build_tools
 
     setup_log_file "${build}"
 
-    validate_build ${machine} ${bsp_version} ${distro_variant}
+    validate_build ${machine} ${bsp_version} ${distro_codename}/${distro}.yaml
 
-    generate_rootfs ${build} ${machine} ${distro_variant}
-    build_bsp ${build} ${machine} ${bsp_version}
-    package_and_clean ${build}
+    generate_rootfs ${distro} ${distro_codename} ${machine}
+    build_bsp ${distro} ${machine} ${bsp_version}
+    package_and_clean ${distro}
 
 done
 

--- a/builds.toml
+++ b/builds.toml
@@ -2,66 +2,127 @@
 
 # Builds for GitHub Actions
 builds = [
-    "am62p-bookworm-09.02.01.010",
-    "am62p-bookworm-09.02.01.010-rt",
-    "am62-bookworm-09.02.01.010",
-    "am62-bookworm-09.02.01.010-rt",
-    "am62lp-bookworm-09.02.01.010",
-    "am62lp-bookworm-09.02.01.010-rt",
-    "am62sip-bookworm-09.02.01.010",
-    "am62sip-bookworm-09.02.01.010-rt",
-    "am64-bookworm-09.02.01.010",
-    "am64-bookworm-09.02.01.010-rt",
+    "trixie-am62pxx-evm",
+    "trixie-rt-am62pxx-evm",
+    "trixie-am62xx-evm",
+    "trixie-rt-am62xx-evm",
+    "trixie-am62xx-lp-evm",
+    "trixie-rt-am62xx-lp-evm",
+    "trixie-am62xxsip-evm",
+    "trixie-rt-am62xxsip-evm",
+    "trixie-am64xx-evm",
+    "trixie-rt-am64xx-evm",
+    "bookworm-am62pxx-evm",
+    "bookworm-rt-am62pxx-evm",
+    "bookworm-am62xx-evm",
+    "bookworm-rt-am62xx-evm",
+    "bookworm-am62xx-lp-evm",
+    "bookworm-rt-am62xx-lp-evm",
+    "bookworm-am62xxsip-evm",
+    "bookworm-rt-am62xxsip-evm",
+    "bookworm-am64xx-evm",
+    "bookworm-rt-am64xx-evm",
 ]
 
-# List of all valid builds
-[am62p-bookworm-09.02.01.010]
+# List of all valid trixie builds
+[trixie-am62pxx-evm]
     machine = "am62pxx-evm"
-    bsp_version = "09.02.00.010"
-    distro_variant = "am62p-bookworm"
+    distro_codename = "trixie"
+    rt_linux = "false"
 
-[am62p-bookworm-09.02.01.010-rt]
+[trixie-rt-am62pxx-evm]
     machine = "am62pxx-evm"
-    bsp_version = "09.02.00.010-rt"
-    distro_variant = "am62p-bookworm-rt"
+    distro_codename = "trixie"
+    rt_linux = "true"
 
-[am62-bookworm-09.02.01.010]
+[trixie-am62xx-evm]
     machine = "am62xx-evm"
-    bsp_version = "09.02.00.010"
-    distro_variant = "am62-bookworm"
+    distro_codename = "trixie"
+    rt_linux = "false"
 
-[am62-bookworm-09.02.01.010-rt]
+[trixie-rt-am62xx-evm]
     machine = "am62xx-evm"
-    bsp_version = "09.02.00.010-rt"
-    distro_variant = "am62-bookworm-rt"
+    distro_codename = "trixie"
+    rt_linux = "true"
 
-[am62lp-bookworm-09.02.01.010]
+[trixie-am62xx-lp-evm]
     machine = "am62xx-lp-evm"
-    bsp_version = "09.02.00.010"
-    distro_variant = "am62-bookworm"
+    distro_codename = "trixie"
+    rt_linux = "false"
 
-[am62lp-bookworm-09.02.01.010-rt]
+[trixie-rt-am62xx-lp-evm]
     machine = "am62xx-lp-evm"
-    bsp_version = "09.02.00.010-rt"
-    distro_variant = "am62-bookworm-rt"
+    distro_codename = "trixie"
+    rt_linux = "true"
 
-[am62sip-bookworm-09.02.01.010]
+[trixie-am62xxsip-evm]
     machine = "am62xxsip-evm"
-    bsp_version = "09.02.00.010"
-    distro_variant = "am62-bookworm"
+    distro_codename = "trixie"
+    rt_linux = "false"
 
-[am62sip-bookworm-09.02.01.010-rt]
+[trixie-rt-am62xxsip-evm]
     machine = "am62xxsip-evm"
-    bsp_version = "09.02.00.010-rt"
-    distro_variant = "am62-bookworm-rt"
+    distro_codename = "trixie"
+    rt_linux = "true"
 
-[am64-bookworm-09.02.01.010]
+[trixie-am64xx-evm]
     machine = "am64xx-evm"
-    bsp_version = "09.02.00.010"
-    distro_variant = "am64-bookworm"
+    distro_codename = "trixie"
+    rt_linux = "false"
 
-[am64-bookworm-09.02.01.010-rt]
+[trixie-rt-am64xx-evm]
     machine = "am64xx-evm"
-    bsp_version = "09.02.00.010-rt"
-    distro_variant = "am64-bookworm-rt"
+    distro_codename = "trixie"
+    rt_linux = "true"
+
+# List of all valid bookworm builds
+[bookworm-am62pxx-evm]
+    machine = "am62pxx-evm"
+    distro_codename = "bookworm"
+    rt_linux = "false"
+
+[bookworm-rt-am62pxx-evm]
+    machine = "am62pxx-evm"
+    distro_codename = "bookworm"
+    rt_linux = "true"
+
+[bookworm-am62xx-evm]
+    machine = "am62xx-evm"
+    distro_codename = "bookworm"
+    rt_linux = "false"
+
+[bookworm-rt-am62xx-evm]
+    machine = "am62xx-evm"
+    distro_codename = "bookworm"
+    rt_linux = "true"
+
+[bookworm-am62xx-lp-evm]
+    machine = "am62xx-lp-evm"
+    distro_codename = "bookworm"
+    rt_linux = "false"
+
+[bookworm-rt-am62xx-lp-evm]
+    machine = "am62xx-lp-evm"
+    distro_codename = "bookworm"
+    rt_linux = "true"
+
+[bookworm-am62xxsip-evm]
+    machine = "am62xxsip-evm"
+    distro_codename = "bookworm"
+    rt_linux = "false"
+
+[bookworm-rt-am62xxsip-evm]
+    machine = "am62xxsip-evm"
+    distro_codename = "bookworm"
+    rt_linux = "true"
+
+[bookworm-am64xx-evm]
+    machine = "am64xx-evm"
+    distro_codename = "bookworm"
+    rt_linux = "false"
+
+[bookworm-rt-am64xx-evm]
+    machine = "am64xx-evm"
+    distro_codename = "bookworm"
+    rt_linux = "true"
 

--- a/configs/bdebstrap_configs/bookworm/bookworm-am62pxx-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-am62pxx-evm.yaml
@@ -1,0 +1,118 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  variant: standard
+  hostname: am62pxx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.1.83-k3
+    - linux-headers-6.1.83-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62p-dkms
+    - ti-img-rogue-firmware-am62p
+    - ti-img-rogue-tools-am62p
+    - ti-img-rogue-umlibs-am62p
+    - firmware-ti-ipc-am62p
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/bookworm/bookworm-am62xx-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-am62xx-evm.yaml
@@ -1,0 +1,118 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  variant: standard
+  hostname: am62xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.1.83-k3
+    - linux-headers-6.1.83-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/bookworm/bookworm-am62xx-lp-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-am62xx-lp-evm.yaml
@@ -1,0 +1,118 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  variant: standard
+  hostname: am62xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.1.83-k3
+    - linux-headers-6.1.83-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/bookworm/bookworm-am62xxsip-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-am62xxsip-evm.yaml
@@ -7,6 +7,7 @@ mmdebstrap:
     - /usr/share/keyrings/debian-archive-keyring.gpg
   suite: bookworm
   variant: standard
+  hostname: am62xxsip-evm
   components:
     - main
     - contrib
@@ -41,11 +42,11 @@ mmdebstrap:
     - linux-headers-6.1.83-k3
     - linux-libc-dev
     - cryptodev-linux-dkms
-    - ti-img-rogue-driver-am62p-dkms
-    - ti-img-rogue-firmware-am62p
-    - ti-img-rogue-tools-am62p
-    - ti-img-rogue-umlibs-am62p
-    - firmware-ti-ipc-am62p
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
     - firmware-cnm-wave
     - libti-rpmsg-char
     - libti-rpmsg-char-dev

--- a/configs/bdebstrap_configs/bookworm/bookworm-am64xx-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-am64xx-evm.yaml
@@ -7,6 +7,7 @@ mmdebstrap:
     - /usr/share/keyrings/debian-archive-keyring.gpg
   suite: bookworm
   variant: standard
+  hostname: am64xx-evm
   components:
     - main
     - contrib
@@ -30,41 +31,17 @@ mmdebstrap:
     - vim
     - k3conf
     - weston
-    - alsa-utils
-    - libasound2-plugins
-    - gstreamer1.0-tools
-    - gstreamer1.0-plugins-base
-    - gstreamer1.0-plugins-good
-    - gstreamer1.0-plugins-bad
-    - i2c-tools
-    - linux-image-6.1.83-k3-rt
-    - linux-headers-6.1.83-k3-rt
+    - linux-image-6.1.83-k3
+    - linux-headers-6.1.83-k3
     - linux-libc-dev
     - cryptodev-linux-dkms
-    - ti-img-rogue-driver-am62-dkms
-    - ti-img-rogue-firmware-am62
-    - ti-img-rogue-tools-am62
-    - ti-img-rogue-umlibs-am62
-    - firmware-ti-ipc-am62
+    - firmware-ti-ipc-am64
     - firmware-cnm-wave
+    - firmware-ti-prueth-am64
+    - firmware-ti-pruhsr-am64
+    - firmware-ti-prusw-am64
     - libti-rpmsg-char
     - libti-rpmsg-char-dev
-    - libd3dadapter9-mesa-dev
-    - libd3dadapter9-mesa
-    - libegl-mesa0
-    - libegl1-mesa
-    - libgbm1
-    - libgl1-mesa-dri
-    - libgl1-mesa-glx
-    - libglapi-mesa
-    - libgles2-mesa
-    - libglx-mesa0
-    - libosmesa6
-    - libwayland-egl1-mesa
-    - mesa-opencl-icd
-    - mesa-va-drivers
-    - mesa-vdpau-drivers
-    - mesa-vulkan-drivers
     - libpru-pssp-dev
     - pru-pssp
     - parted
@@ -96,14 +73,6 @@ mmdebstrap:
     - 'chroot "$1" apt-get update'
       # Setup .bashrc for clean command-line experience
     - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
-      # Weston Service and Config Files
-    - 'chroot "$1" mkdir -p /etc/systemd/system/'
-    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
-    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
-    - 'chroot "$1" mkdir -p /etc/default/'
-    - 'upload target/weston/weston /etc/default/weston'
-    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
-    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
       # Enable ssh to root user without password
     - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
     - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'

--- a/configs/bdebstrap_configs/bookworm/bookworm-rt-am62pxx-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-rt-am62pxx-evm.yaml
@@ -1,0 +1,118 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  variant: standard
+  hostname: am62pxx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.1.83-k3-rt
+    - linux-headers-6.1.83-k3-rt
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62p-dkms
+    - ti-img-rogue-firmware-am62p
+    - ti-img-rogue-tools-am62p
+    - ti-img-rogue-umlibs-am62p
+    - firmware-ti-ipc-am62p
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/bookworm/bookworm-rt-am62xx-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-rt-am62xx-evm.yaml
@@ -7,6 +7,7 @@ mmdebstrap:
     - /usr/share/keyrings/debian-archive-keyring.gpg
   suite: bookworm
   variant: standard
+  hostname: am62xx-evm
   components:
     - main
     - contrib
@@ -41,11 +42,11 @@ mmdebstrap:
     - linux-headers-6.1.83-k3-rt
     - linux-libc-dev
     - cryptodev-linux-dkms
-    - ti-img-rogue-driver-am62p-dkms
-    - ti-img-rogue-firmware-am62p
-    - ti-img-rogue-tools-am62p
-    - ti-img-rogue-umlibs-am62p
-    - firmware-ti-ipc-am62p
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
     - firmware-cnm-wave
     - libti-rpmsg-char
     - libti-rpmsg-char-dev

--- a/configs/bdebstrap_configs/bookworm/bookworm-rt-am62xx-lp-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-rt-am62xx-lp-evm.yaml
@@ -7,6 +7,7 @@ mmdebstrap:
     - /usr/share/keyrings/debian-archive-keyring.gpg
   suite: bookworm
   variant: standard
+  hostname: am62xx-lp-evm
   components:
     - main
     - contrib
@@ -37,8 +38,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.1.83-k3
-    - linux-headers-6.1.83-k3
+    - linux-image-6.1.83-k3-rt
+    - linux-headers-6.1.83-k3-rt
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/bookworm/bookworm-rt-am62xxsip-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-rt-am62xxsip-evm.yaml
@@ -7,6 +7,7 @@ mmdebstrap:
     - /usr/share/keyrings/debian-archive-keyring.gpg
   suite: bookworm
   variant: standard
+  hostname: am62xxsip-evm
   components:
     - main
     - contrib
@@ -30,17 +31,41 @@ mmdebstrap:
     - vim
     - k3conf
     - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
     - linux-image-6.1.83-k3-rt
     - linux-headers-6.1.83-k3-rt
     - linux-libc-dev
     - cryptodev-linux-dkms
-    - firmware-ti-ipc-am64
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
     - firmware-cnm-wave
-    - firmware-ti-prueth-am64
-    - firmware-ti-pruhsr-am64
-    - firmware-ti-prusw-am64
     - libti-rpmsg-char
     - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
     - libpru-pssp-dev
     - pru-pssp
     - parted
@@ -72,6 +97,14 @@ mmdebstrap:
     - 'chroot "$1" apt-get update'
       # Setup .bashrc for clean command-line experience
     - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
       # Enable ssh to root user without password
     - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
     - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'

--- a/configs/bdebstrap_configs/bookworm/bookworm-rt-am64xx-evm.yaml
+++ b/configs/bdebstrap_configs/bookworm/bookworm-rt-am64xx-evm.yaml
@@ -1,0 +1,86 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: bookworm
+  variant: standard
+  hostname: am64xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - linux-image-6.1.83-k3-rt
+    - linux-headers-6.1.83-k3-rt
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - firmware-ti-ipc-am64
+    - firmware-cnm-wave
+    - firmware-ti-prueth-am64
+    - firmware-ti-pruhsr-am64
+    - firmware-ti-prusw-am64
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-am62pxx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62pxx-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62pxx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3
+    - linux-headers-6.6.32-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62p-dkms
+    - ti-img-rogue-firmware-am62p
+    - ti-img-rogue-tools-am62p
+    - ti-img-rogue-umlibs-am62p
+    - firmware-ti-ipc-am62p
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-am62xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62xx-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3
+    - linux-headers-6.6.32-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-am62xx-lp-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62xx-lp-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3
+    - linux-headers-6.6.32-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-am62xxsip-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62xxsip-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62xxsip-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3
+    - linux-headers-6.6.32-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-am64xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am64xx-evm.yaml
@@ -1,0 +1,87 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am64xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - linux-image-6.6.32-k3
+    - linux-headers-6.6.32-k3
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - firmware-ti-ipc-am64
+    - firmware-cnm-wave
+    - firmware-ti-prueth-am64
+    - firmware-ti-pruhsr-am64
+    - firmware-ti-prusw-am64
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62pxx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62pxx-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62pxx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3-rt
+    - linux-headers-6.6.32-k3-rt
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62p-dkms
+    - ti-img-rogue-firmware-am62p
+    - ti-img-rogue-tools-am62p
+    - ti-img-rogue-umlibs-am62p
+    - firmware-ti-ipc-am62p
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-evm.yaml
@@ -5,8 +5,9 @@ mmdebstrap:
   mode: auto
   keyrings:
     - /usr/share/keyrings/debian-archive-keyring.gpg
-  suite: bookworm
+  suite: trixie
   variant: standard
+  hostname: am62xx-evm
   components:
     - main
     - contrib
@@ -30,17 +31,41 @@ mmdebstrap:
     - vim
     - k3conf
     - weston
-    - linux-image-6.1.83-k3
-    - linux-headers-6.1.83-k3
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3-rt
+    - linux-headers-6.6.32-k3-rt
     - linux-libc-dev
     - cryptodev-linux-dkms
-    - firmware-ti-ipc-am64
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
     - firmware-cnm-wave
-    - firmware-ti-prueth-am64
-    - firmware-ti-pruhsr-am64
-    - firmware-ti-prusw-am64
     - libti-rpmsg-char
     - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
     - libpru-pssp-dev
     - pru-pssp
     - parted
@@ -51,6 +76,7 @@ mmdebstrap:
       # Setup TI Debian Package Repository
     - 'mkdir -p $1/etc/apt/sources.list.d/'
     - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
       # Setup Apt repository preferences
     - 'mkdir -p $1/etc/apt/preferences.d/'
     - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
@@ -72,6 +98,14 @@ mmdebstrap:
     - 'chroot "$1" apt-get update'
       # Setup .bashrc for clean command-line experience
     - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
       # Enable ssh to root user without password
     - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
     - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-lp-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-lp-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62xx-lp-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3-rt
+    - linux-headers-6.6.32-k3-rt
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62xxsip-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62xxsip-evm.yaml
@@ -1,0 +1,119 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am62xxsip-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - alsa-utils
+    - libasound2-plugins
+    - gstreamer1.0-tools
+    - gstreamer1.0-plugins-base
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-plugins-bad
+    - i2c-tools
+    - linux-image-6.6.32-k3-rt
+    - linux-headers-6.6.32-k3-rt
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - ti-img-rogue-driver-am62-dkms
+    - ti-img-rogue-firmware-am62
+    - ti-img-rogue-tools-am62
+    - ti-img-rogue-umlibs-am62
+    - firmware-ti-ipc-am62
+    - firmware-cnm-wave
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libd3dadapter9-mesa-dev
+    - libd3dadapter9-mesa
+    - libegl-mesa0
+    - libegl1-mesa
+    - libgbm1
+    - libgl1-mesa-dri
+    - libgl1-mesa-glx
+    - libglapi-mesa
+    - libgles2-mesa
+    - libglx-mesa0
+    - libosmesa6
+    - libwayland-egl1-mesa
+    - mesa-opencl-icd
+    - mesa-va-drivers
+    - mesa-vdpau-drivers
+    - mesa-vulkan-drivers
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Weston Service and Config Files
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/weston/weston.service /etc/systemd/system/weston.service'
+    - 'upload target/weston/weston.socket /etc/systemd/system/weston.socket'
+    - 'chroot "$1" mkdir -p /etc/default/'
+    - 'upload target/weston/weston /etc/default/weston'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" weston'
+    - 'chroot "$1" echo "export WAYLAND_DISPLAY=wayland-1" >> $1/etc/profile'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am64xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am64xx-evm.yaml
@@ -1,0 +1,87 @@
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  keyrings:
+    - /usr/share/keyrings/debian-archive-keyring.gpg
+  suite: trixie
+  variant: standard
+  hostname: am64xx-evm
+  components:
+    - main
+    - contrib
+    - non-free-firmware
+  packages:
+    - build-essential
+    - gpg
+    - curl
+    - firmware-ti-connectivity
+    - init
+    - iproute2
+    - less
+    - libdrm-dev
+    - libpam-systemd
+    - locales
+    - neofetch
+    - network-manager
+    - net-tools
+    - openssh-server
+    - sudo
+    - vim
+    - k3conf
+    - weston
+    - linux-image-6.6.32-k3-rt
+    - linux-headers-6.6.32-k3-rt
+    - linux-libc-dev
+    - cryptodev-linux-dkms
+    - firmware-ti-ipc-am64
+    - firmware-cnm-wave
+    - firmware-ti-prueth-am64
+    - firmware-ti-pruhsr-am64
+    - firmware-ti-prusw-am64
+    - libti-rpmsg-char
+    - libti-rpmsg-char-dev
+    - libpru-pssp-dev
+    - pru-pssp
+    - parted
+    - e2fsprogs
+  mirrors:
+    - http://deb.debian.org/debian
+  setup-hooks:
+      # Setup TI Debian Package Repository
+    - 'mkdir -p $1/etc/apt/sources.list.d/'
+    - 'wget https://raw.githubusercontent.com/TexasInstruments/ti-debpkgs/main/ti-debpkgs.sources -P $1/etc/apt/sources.list.d/'
+    - 'sed -i "s/bookworm/trixie/g" $1/etc/apt/sources.list.d/ti-debpkgs.sources'
+      # Setup Apt repository preferences
+    - 'mkdir -p $1/etc/apt/preferences.d/'
+    - 'printf "Package: *\nPin: origin TexasInstruments.github.io\nPin-Priority: 1001" >> $1/etc/apt/preferences.d/ti-debpkgs'
+      # Setup Kernel post-install scripts
+    - 'mkdir -p $1/etc/kernel/postinst.d/'
+    - 'echo "PWD = $PWD"'
+    - 'upload target/kernel/postinst.d/cp-kernel-and-overlays /etc/kernel/postinst.d/cp-kernel-and-overlays'
+    - 'chmod a+x $1/etc/kernel/postinst.d/cp-kernel-and-overlays'
+  essential-hooks:
+    # FIXME: Find a better workaround instead of sleep
+    - 'sleep 10' # workaround for /proc resource busy unable to umount issue
+  customize-hooks:
+      # Remove passwd for root user
+    - 'chroot "$1" passwd --delete root'
+      # Fix apt install mandb permission issue
+    - 'chroot "$1" chown -R man: /var/cache/man/'
+    - 'chroot "$1" chmod -R 755 /var/cache/man/'
+      # update packages to avoid mandatory update after first boot
+    - 'chroot "$1" apt-get update'
+      # Setup .bashrc for clean command-line experience
+    - 'chroot "$1" cp /etc/skel/.bashrc ~/.bashrc'
+      # Enable ssh to root user without password
+    - 'chroot "$1" echo "PermitRootLogin yes" >> $1/etc/ssh/sshd_config'
+    - 'chroot "$1" echo "PermitEmptyPasswords yes" >> $1/etc/ssh/sshd_config'
+      # Resize Rootfs Service
+    - 'chroot "$1" mkdir -p /usr/bin'
+    - 'upload target/resize_rootfs/resize_rootfs.sh /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" chmod a+x /usr/bin/resize_rootfs.sh'
+    - 'chroot "$1" mkdir -p /etc/systemd/system/'
+    - 'upload target/resize_rootfs/resize_rootfs.service /etc/systemd/system/resize_rootfs.service'
+    - '$BDEBSTRAP_HOOKS/enable-units "$1" resize_rootfs'
+

--- a/configs/bsp_sources.toml
+++ b/configs/bsp_sources.toml
@@ -1,61 +1,20 @@
+# BSP selection based on variant of filesystem
+[trixie]
+    bsp_version = "10.00.05"
+
+[bookworm]
+    bsp_version = "09.02.00.010"
+
+# BSP Configurations
+[10.00.05]
+    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
+    optee_srcrev = "12d7c4ee4642d2d761e39fbcf21a06fb77141dea"
+    uboot_srcrev = "10.00.05"
+    linux_fw_srcrev = "10.00.05"
+
 [09.02.00.010]
     atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
     optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
     uboot_srcrev = "09.02.00.010"
     linux_fw_srcrev = "09.02.00.010"
-
-[09.02.00.010-rt]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.010"
-    linux_fw_srcrev = "09.02.00.010"
-
-[09.02.00.009]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.009"
-    linux_fw_srcrev = "09.02.00.009"
-
-[09.02.00.009-rt]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.009"
-    linux_fw_srcrev = "09.02.00.009"
-
-
-[09.02.00.008]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.008"
-    linux_fw_srcrev = "09.02.00.008"
-
-[09.02.00.008-rt]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.008"
-    linux_fw_srcrev = "09.02.00.008"
-
-[09.02.00.006]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.006"
-    linux_fw_srcrev = "09.02.00.006"
-
-[09.02.00.006-rt]
-    atf_srcrev = "00f1ec6b8740ccd403e641131e294aabacf2a48b"
-    optee_srcrev = "012cdca49db398693903e05c42a254a3a0c0d8f2"
-    uboot_srcrev = "09.02.00.006"
-    linux_fw_srcrev = "09.02.00.006"
-
-[09.02.00.001]
-    atf_srcrev = "d7a7135d32a8c7da004c0c19b75bd4e2813f9759"
-    optee_srcrev = "2a5b1d1232f582056184367fb58a425ac7478ec6"
-    uboot_srcrev = "09.02.00.001"
-    linux_fw_srcrev = "09.02.00.001"
-
-[09.02.00.001-rt]
-    atf_srcrev = "d7a7135d32a8c7da004c0c19b75bd4e2813f9759"
-    optee_srcrev = "2a5b1d1232f582056184367fb58a425ac7478ec6"
-    uboot_srcrev = "09.02.00.001"
-    linux_fw_srcrev = "09.02.00.001"
 

--- a/configs/machines/09.02.00.010.yaml
+++ b/configs/machines/09.02.00.010.yaml
@@ -1,0 +1,46 @@
+# This file describes various machine specific settings needed for the build
+
+[am62pxx-evm]
+    # u-boot config
+    atf_target_board = "lite"
+    atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
+    optee_platform = "k3-am62x"
+    optee_make_args = "CFG_WITH_SOFTWARE_PRNG=y CFG_TEE_CORE_LOG_LEVEL=1"
+    uboot_r5_defconfig = "am62px_evm_r5_defconfig"
+    uboot_a53_defconfig = "am62px_evm_a53_defconfig"
+
+[am62xx-evm]
+    # u-boot config
+    atf_target_board = "lite"
+    atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
+    optee_platform = "k3-am62x"
+    optee_make_args = "CFG_TEE_CORE_LOG_LEVEL=1"
+    uboot_r5_defconfig = "am62x_evm_r5_defconfig"
+    uboot_a53_defconfig = "am62x_evm_a53_defconfig"
+
+[am62xx-lp-evm]
+    # u-boot config
+    atf_target_board = "lite"
+    atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
+    optee_platform = "k3-am62x"
+    optee_make_args = "CFG_TEE_CORE_LOG_LEVEL=1"
+    uboot_r5_defconfig = "am62x_lpsk_r5_defconfig"
+    uboot_a53_defconfig = "am62x_lpsk_a53_defconfig"
+
+[am62xxsip-evm]
+    # u-boot config
+    atf_target_board = "lite"
+    atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
+    optee_platform = "k3-am62x"
+    optee_make_args = "CFG_TEE_CORE_LOG_LEVEL=1"
+    uboot_r5_defconfig = "am62x_evm_r5_defconfig,am62xsip_sk_r5.config"
+    uboot_a53_defconfig = "am62x_evm_a53_defconfig"
+
+[am64xx-evm]
+    # u-boot config
+    atf_target_board = "lite"
+    atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
+    optee_platform = "k3-am64x"
+    optee_make_args = "."
+    uboot_r5_defconfig = "am64x_evm_r5_defconfig"
+    uboot_a53_defconfig = "am64x_evm_a53_defconfig"

--- a/configs/machines/10.00.05.yaml
+++ b/configs/machines/10.00.05.yaml
@@ -1,8 +1,6 @@
 # This file describes various machine specific settings needed for the build
 
 [am62pxx-evm]
-    # device config
-    hostname = "am62pxx-evm"
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
@@ -12,8 +10,6 @@
     uboot_a53_defconfig = "am62px_evm_a53_defconfig"
 
 [am62xx-evm]
-    # device config
-    hostname = "am62xx-evm"
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
@@ -23,8 +19,6 @@
     uboot_a53_defconfig = "am62x_evm_a53_defconfig"
 
 [am62xx-lp-evm]
-    # device config
-    hostname = "am62xx-lp-evm"
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
@@ -34,19 +28,15 @@
     uboot_a53_defconfig = "am62x_lpsk_a53_defconfig"
 
 [am62xxsip-evm]
-    # device config
-    hostname = "am62xxsip-evm"
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
     optee_platform = "k3-am62x"
     optee_make_args = "CFG_TEE_CORE_LOG_LEVEL=1"
-    uboot_r5_defconfig = "am62x_evm_r5_defconfig,am62xsip_sk_r5.config"
-    uboot_a53_defconfig = "am62x_evm_a53_defconfig"
+    uboot_r5_defconfig = "am62xsip_evm_r5_defconfig"
+    uboot_a53_defconfig = "am62xsip_evm_a53_defconfig"
 
 [am64xx-evm]
-    # device config
-    hostname = "am64xx-evm"
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"

--- a/create-sdcard.sh
+++ b/create-sdcard.sh
@@ -47,7 +47,8 @@ EXE=`echo $0 | sed s=$PWD==`
 EXEPATH="$PWD"/"$EXE"
 clear
 
-PARSEPATH=./build/$1
+build=${1}
+PARSEPATH=./build/${build}
 
 cat << EOM
 
@@ -689,8 +690,8 @@ sync
 sync
 sync
 
-BOOTFILEPATH="$PARSEPATH/tisdk*boot.tar.xz"
-ROOTFILEPATH="$PARSEPATH/tisdk*rootfs.tar.xz"
+BOOTFILEPATH="$PARSEPATH/tisdk-debian-${build}-boot.tar.xz"
+ROOTFILEPATH="$PARSEPATH/tisdk-debian-${build}-rootfs.tar.xz"
 
 cat << EOM
 ################################################################################

--- a/create-wic.sh
+++ b/create-wic.sh
@@ -82,15 +82,18 @@ fi
 source ${topdir}/scripts/common.sh
 
 validate_section "Build" ${BUILD} "${topdir}/builds.toml"
-machine=($(read_build_config ${BUILD} machine))
-bsp_version=($(read_build_config ${BUILD} bsp_version))
-distro_variant=($(read_build_config ${BUILD} distro_variant))
 
-if [[ $bsp_version == *"-rt"* ]]; then
-    IMAGE=tisdk-debian-bookworm-rt-${machine}.wic
-else
-    IMAGE=tisdk-debian-bookworm-${machine}.wic
+if [ ! -f ${topdir}/build/${BUILD}/tisdk-debian-${BUILD}-boot.tar.xz ]; then
+    echo "Error: Boot partition tarball not found for ${BUILD}."
+    exit -1
 fi
+
+if [ ! -f ${topdir}/build/${BUILD}/tisdk-debian-${BUILD}-rootfs.tar.xz ]; then
+    echo "Error: RootFS partition tarball not found for ${BUILD}."
+    exit -1
+fi
+
+IMAGE=tisdk-debian-${BUILD}.wic
 
 echo "Creating an empty image"
 dd if=/dev/zero of=${BUILDPATH}/${BUILD}/${IMAGE} count=6291456 status=progress
@@ -130,9 +133,9 @@ mount ${LOOPDEV}p1 ./img_boot
 
 echo "Copy Boot Partition files"
 cd ./img_boot
-tar -xf ${BUILDPATH}/${BUILD}/tisdk-${distro_variant}-${machine}-boot.tar.xz
-mv tisdk-${distro_variant}-${machine}-boot/* ./
-rmdir tisdk-${distro_variant}-${machine}-boot
+tar -xf ${BUILDPATH}/${BUILD}/tisdk-debian-${BUILD}-boot.tar.xz
+mv tisdk-debian-${BUILD}-boot/* ./
+rmdir tisdk-debian-${BUILD}-boot
 
 echo "Sync and Unmount Boot Partition"
 cd ${BUILDPATH}/${BUILD}/temp/
@@ -146,9 +149,9 @@ mount ${LOOPDEV}p2 ./img_rootfs
 
 echo "Copy RootFS Partition files"
 cd ./img_rootfs
-tar -xf ${BUILDPATH}/${BUILD}/tisdk-${distro_variant}-${machine}-rootfs.tar.xz
-mv tisdk-${distro_variant}-${machine}-rootfs/* ./
-rmdir tisdk-${distro_variant}-${machine}-rootfs
+tar -xf ${BUILDPATH}/${BUILD}/tisdk-debian-${BUILD}-rootfs.tar.xz
+mv tisdk-debian-${BUILD}-rootfs/* ./
+rmdir tisdk-debian-${BUILD}-rootfs
 
 echo "Sync and Unmount RootFS Partition"
 cd ${BUILDPATH}/${BUILD}/temp/

--- a/scripts/build_distro.sh
+++ b/scripts/build_distro.sh
@@ -3,23 +3,24 @@
 source ${topdir}/scripts/common.sh
 
 function generate_rootfs() {
-build=$1
-machine=$2
-distro=$3
+distro=$1
+distro_codename=$2
+machine=$3
 
     cd ${topdir}
 
-    hostname=($(read_machine_config ${machine} hostname))
     log "> Building rootfs .."
     bdebstrap \
-        -c ${topdir}/configs/bdebstrap_configs/${distro}.yaml \
-        --name ${topdir}/build/${build} \
-        --target tisdk-${distro}-${machine}-rootfs \
-        --hostname "${hostname}" -f &>>"${LOG_FILE}"
+        -c ${topdir}/configs/bdebstrap_configs/${distro_codename}/${distro}.yaml \
+        --name ${topdir}/build/${distro} \
+        --target tisdk-debian-${distro}-rootfs \
+        --hostname ${machine} \
+        -f \
+        &>>"${LOG_FILE}"
 
     cd ${topdir}/build/
 
-    ROOTFS_DIR=${topdir}/build/${build}/tisdk-${distro}-${machine}-rootfs
+    ROOTFS_DIR=${topdir}/build/${distro}/tisdk-debian-${distro}}-rootfs
 }
 
 function package_and_clean() {
@@ -28,11 +29,11 @@ build=$1
     cd ${topdir}/build/${build}
 
     log "> Cleaning up ${build}"
-    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-${distro}-${machine}-rootfs.tar.xz tisdk-${distro}-${machine}-rootfs &>>"${LOG_FILE}"
-    rm -rf tisdk-${distro}-${machine}-rootfs
+    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-rootfs.tar.xz tisdk-debian-${distro}-rootfs &>>"${LOG_FILE}"
+    rm -rf tisdk-debian-${distro}-rootfs
 
-    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-${distro}-${machine}-boot.tar.xz tisdk-${distro}-${machine}-boot &>>"${LOG_FILE}"
-    rm -rf tisdk-${distro}-${machine}-boot
+    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-boot.tar.xz tisdk-debian-${distro}-boot &>>"${LOG_FILE}"
+    rm -rf tisdk-debian-${distro}-boot
 
     rm -rf bsp_sources
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -18,8 +18,9 @@ function read_config() {
 function read_machine_config() {
 machine=$1
 config=$2
+bsp_version=${3}
 
-    read_config ${topdir}/configs/machines.toml $machine $config
+    read_config ${topdir}/configs/machines/${bsp_version}.yaml $machine $config
 }
 
 function read_bsp_config() {
@@ -50,13 +51,13 @@ config=$3
 function validate_build() {
 machine=$1
 bsp_version=$2
-distro_variant=$3
+distro_file=$3
 
-    validate_section "Machine" ${machine} "${topdir}/configs/machines.toml"
     validate_section "BSP Version" ${bsp_version} "${topdir}/configs/bsp_sources.toml"
+    validate_section "Machine" ${machine} "${topdir}/configs/machines/${bsp_version}.yaml"
 
-    if [ ! -f "${topdir}/configs/bdebstrap_configs/${distro_variant}.yaml" ] ; then
-        log "Distro Variant \"${distro_variant}\" does not exist. Exiting."
+    if [ ! -f "${topdir}/configs/bdebstrap_configs/${distro_file}" ] ; then
+        log "Distro Variant \"${distro_file}\" does not exist. Exiting."
         exit 1
     fi
 }


### PR DESCRIPTION
- Migrate BSP to 10.00.
- Add bdebstrap configs for Trixie.
- Add bsp_version specific machine configuration files.
- Lock distro_variant to a specific version of BSPs to avoid dependency issues.
- Update build names to be more guessable.
- Update paths and names in create-sdcard and create-wic scripts according to the above change.