### PR TITLE
weston.service : rather handle --idle-time from /etc/xdg/weston/weston.ini

### DIFF
--- a/target/etc/xdg/weston/weston.ini
+++ b/target/etc/xdg/weston/weston.ini
@@ -1,0 +1,2 @@
+[core]
+idle-time=0

--- a/target/weston/weston.service
+++ b/target/weston/weston.service
@@ -34,7 +34,7 @@ ConditionPathExists=/dev/tty0
 # Requires systemd-notify.so Weston plugin.
 Type=simple
 EnvironmentFile=/etc/default/weston
-ExecStart=/usr/bin/weston --backend=drm-backend.so --continue-without-input --idle-time=0
+ExecStart=/usr/bin/weston --backend=drm-backend.so --continue-without-input
 
 # Optional watchdog setup
 #TimeoutStartSec=60


### PR DESCRIPTION
When "--idle-time" is specified in weston.service cmdline,
It will supersede any value set in /etc/xdg/weston/weston.ini, becoming useless.

This MR is proposing to handle rather this "--idle-time" value in a new provided weston.ini file in target dir,
achieving strictly same result (setting it to 0 == de-activating it),
but letting any downstream test job testing/debugging resuming from suspend,
adding much less divergence from master branch,
thus easier to maintain.

thanks in advance