### PR TITLE
Add BSP version to the names of output tars and wics

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -68,12 +68,16 @@ jobs:
         run: |
           mkdir -p build
           sudo ./build.sh ${{ matrix.builds }}
+          distro_codename=($(toml get ${{ matrix.builds }}.distro_codename --toml-path ./builds.toml))
+          bsp_version=($(toml get ${distro_codename}.bsp_version --toml-path ./configs/bsp_sources.toml))
+          builds_out="${{ matrix.builds }}-${bsp_version}"
+          echo "builds_out=${builds_out}" >>$GITHUB_ENV
 
-      - name: Upload ${{ matrix.builds }}
+      - name: Upload ${{ env.builds_out }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          path: build/${{ matrix.builds }}.tar.xz
-          name: ${{ matrix.builds }}
+          path: build/${{ env.builds_out }}.tar.xz
+          name: ${{ env.builds_out }}
           if-no-files-found: error
 
       - name: Upload ${{ matrix.builds }}.log

--- a/build.sh
+++ b/build.sh
@@ -68,9 +68,9 @@ do
 
     validate_build ${machine} ${bsp_version} ${distro_codename}/${distro}.yaml
 
-    generate_rootfs ${distro} ${distro_codename} ${machine}
+    generate_rootfs ${distro} ${distro_codename} ${machine} ${bsp_version}
     build_bsp ${distro} ${machine} ${bsp_version}
-    package_and_clean ${distro}
+    package_and_clean ${distro} ${bsp_version}
 
 done
 

--- a/create-wic.sh
+++ b/create-wic.sh
@@ -83,17 +83,21 @@ source ${topdir}/scripts/common.sh
 
 validate_section "Build" ${BUILD} "${topdir}/builds.toml"
 
-if [ ! -f ${topdir}/build/${BUILD}/tisdk-debian-${BUILD}-boot.tar.xz ]; then
+
+distro_codename=($(read_build_config ${BUILD} distro_codename))
+bsp_version=($(read_bsp_config ${distro_codename} bsp_version))
+
+if [ ! -f ${topdir}/build/${BUILD}/tisdk-debian-${BUILD}-${bsp_version}-boot.tar.xz ]; then
     echo "Error: Boot partition tarball not found for ${BUILD}."
     exit -1
 fi
 
-if [ ! -f ${topdir}/build/${BUILD}/tisdk-debian-${BUILD}-rootfs.tar.xz ]; then
+if [ ! -f ${topdir}/build/${BUILD}/tisdk-debian-${BUILD}-${bsp_version}-rootfs.tar.xz ]; then
     echo "Error: RootFS partition tarball not found for ${BUILD}."
     exit -1
 fi
 
-IMAGE=tisdk-debian-${BUILD}.wic
+IMAGE=tisdk-debian-${BUILD}-${bsp_version}.wic
 
 echo "Creating an empty image"
 dd if=/dev/zero of=${BUILDPATH}/${BUILD}/${IMAGE} count=10485760 status=progress
@@ -133,9 +137,9 @@ mount ${LOOPDEV}p1 ./img_boot
 
 echo "Copy Boot Partition files"
 cd ./img_boot
-tar -xf ${BUILDPATH}/${BUILD}/tisdk-debian-${BUILD}-boot.tar.xz
-mv tisdk-debian-${BUILD}-boot/* ./
-rmdir tisdk-debian-${BUILD}-boot
+tar -xf ${BUILDPATH}/${BUILD}/tisdk-debian-${BUILD}-${bsp_version}-boot.tar.xz
+mv tisdk-debian-${BUILD}-${bsp_version}-boot/* ./
+rmdir tisdk-debian-${BUILD}-${bsp_version}-boot
 
 echo "Sync and Unmount Boot Partition"
 cd ${BUILDPATH}/${BUILD}/temp/
@@ -149,9 +153,9 @@ mount ${LOOPDEV}p2 ./img_rootfs
 
 echo "Copy RootFS Partition files"
 cd ./img_rootfs
-tar -xf ${BUILDPATH}/${BUILD}/tisdk-debian-${BUILD}-rootfs.tar.xz
-mv tisdk-debian-${BUILD}-rootfs/* ./
-rmdir tisdk-debian-${BUILD}-rootfs
+tar -xf ${BUILDPATH}/${BUILD}/tisdk-debian-${BUILD}-${bsp_version}-rootfs.tar.xz
+mv tisdk-debian-${BUILD}-${bsp_version}-rootfs/* ./
+rmdir tisdk-debian-${BUILD}-${bsp_version}-rootfs
 
 echo "Sync and Unmount RootFS Partition"
 cd ${BUILDPATH}/${BUILD}/temp/

--- a/scripts/build_bsp.sh
+++ b/scripts/build_bsp.sh
@@ -94,7 +94,7 @@ bsp_version=$3
     tar --use-compress-program="pigz --best --recursive | pv" -cf bsp_sources.tar.xz bsp_sources &>>"${LOG_FILE}"
     log "> BSP sources: backup created .."
 
-    mkdir -p tisdk-debian-${distro}-boot
+    mkdir -p tisdk-debian-${distro}-${bsp_version}-boot
 }
 
 function build_atf() {
@@ -137,18 +137,18 @@ bsp_version=$2
     log "> uboot-r5: building .."
     make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- ${uboot_r5_defconfig} O=${UBOOT_DIR}/out/r5 &>>"${LOG_FILE}"
     make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- O=${UBOOT_DIR}/out/r5 BINMAN_INDIRS=${FW_DIR} &>>"${LOG_FILE}"
-    cp ${UBOOT_DIR}/out/r5/tiboot3*.bin ${topdir}/build/${build}/tisdk-debian-${distro}-boot/ &>> ${LOG_FILE}
+    cp ${UBOOT_DIR}/out/r5/tiboot3*.bin ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
 
     cd ${UBOOT_DIR}
     log "> uboot-a53: building .."
     make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} ${uboot_a53_defconfig} O=${UBOOT_DIR}/out/a53 &>>"${LOG_FILE}"
     make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} BL31=${TFA_DIR}/build/k3/lite/release/bl31.bin TEE=${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin O=${UBOOT_DIR}/out/a53 BINMAN_INDIRS=${topdir}/build/${build}/bsp_sources/ti-linux-firmware &>>"${LOG_FILE}"
-    cp ${UBOOT_DIR}/out/a53/tispl.bin ${topdir}/build/${build}/tisdk-debian-${distro}-boot/ &>> ${LOG_FILE}
-    cp ${UBOOT_DIR}/out/a53/u-boot.img ${topdir}/build/${build}/tisdk-debian-${distro}-boot/ &>> ${LOG_FILE}
+    cp ${UBOOT_DIR}/out/a53/tispl.bin ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
+    cp ${UBOOT_DIR}/out/a53/u-boot.img ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
 
 	case ${machine} in
 		am62pxx-evm | am62xx-evm | am62xx-lp-evm | am62xxsip-evm)
-			cp ${UBOOT_DIR}/tools/logos/ti_logo_414x97_32bpp.bmp.gz ${topdir}/build/${build}/tisdk-debian-${distro}-boot/ &>> ${LOG_FILE}
+			cp ${UBOOT_DIR}/tools/logos/ti_logo_414x97_32bpp.bmp.gz ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
 			;;
 	esac
 }

--- a/scripts/build_distro.sh
+++ b/scripts/build_distro.sh
@@ -6,6 +6,7 @@ function generate_rootfs() {
 distro=$1
 distro_codename=$2
 machine=$3
+bsp_version=$4
 
     cd ${topdir}
 
@@ -13,7 +14,7 @@ machine=$3
     bdebstrap \
         -c ${topdir}/configs/bdebstrap_configs/${distro_codename}/${distro}.yaml \
         --name ${topdir}/build/${distro} \
-        --target tisdk-debian-${distro}-rootfs \
+        --target tisdk-debian-${distro}-${bsp_version}-rootfs \
         --hostname ${machine} \
         -f \
         &>>"${LOG_FILE}"
@@ -25,21 +26,22 @@ machine=$3
 
 function package_and_clean() {
 build=$1
+bsp_version=$2
 
     cd ${topdir}/build/${build}
 
     log "> Cleaning up ${build}"
-    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-rootfs.tar.xz tisdk-debian-${distro}-rootfs &>>"${LOG_FILE}"
+    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-${bsp_version}-rootfs.tar.xz tisdk-debian-${distro}-${bsp_version}-rootfs &>>"${LOG_FILE}"
     rm -rf tisdk-debian-${distro}-rootfs
 
-    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-boot.tar.xz tisdk-debian-${distro}-boot &>>"${LOG_FILE}"
-    rm -rf tisdk-debian-${distro}-boot
+    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-${bsp_version}-boot.tar.xz tisdk-debian-${distro}-${bsp_version}-boot &>>"${LOG_FILE}"
+    rm -rf tisdk-debian-${distro}-${bsp_version}-boot
 
     rm -rf bsp_sources
 
     cd ${topdir}/build/
 
     log "> Packaging ${build}"
-    tar --use-compress-program="pigz --best --recursive | pv" -cf ${build}.tar.xz ${build} &>>"${LOG_FILE}"
+    tar --use-compress-program="pigz --best --recursive | pv" -cf ${distro}-${bsp_version}.tar.xz ${build} &>>"${LOG_FILE}"
 }
 


### PR DESCRIPTION
There is a requirement to include the BSP versions in the names of the images we distribute. So include the version in the name.