### PR TITLE
Fix LPM: Return and use array instead of just 1st string

### DIFF
--- a/configs/machines/09.02.00.010.toml
+++ b/configs/machines/09.02.00.010.toml
@@ -4,7 +4,7 @@
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
-    optee_platform = "k3-am62x"
+    optee_platform = "k3-am62px"
     optee_make_args = "CFG_WITH_SOFTWARE_PRNG=y CFG_TEE_CORE_LOG_LEVEL=1"
     uboot_r5_defconfig = "am62px_evm_r5_defconfig"
     uboot_a53_defconfig = "am62px_evm_a53_defconfig"

--- a/configs/machines/10.01.08.02.toml
+++ b/configs/machines/10.01.08.02.toml
@@ -4,7 +4,7 @@
     # u-boot config
     atf_target_board = "lite"
     atf_make_args="K3_PM_SYSTEM_SUSPEND=1"
-    optee_platform = "k3-am62x"
+    optee_platform = "k3-am62px"
     optee_make_args = "CFG_WITH_SOFTWARE_PRNG=y CFG_TEE_CORE_LOG_LEVEL=1"
     uboot_r5_defconfig = "am62px_evm_r5_defconfig"
     uboot_a53_defconfig = "am62px_evm_a53_defconfig"

--- a/scripts/build_bsp.sh
+++ b/scripts/build_bsp.sh
@@ -122,7 +122,7 @@ bsp_version=$2
     fi
 
     log "> optee: building .."
-    make -j`nproc` CROSS_COMPILE64=${cross_compile} CROSS_COMPILE=arm-none-linux-gnueabihf- PLATFORM=${platform} CFG_ARM64_core=y ${make_args} &>>"${LOG_FILE}"
+    make -j`nproc` CROSS_COMPILE64=${cross_compile} CROSS_COMPILE=arm-none-linux-gnueabihf- PLATFORM=${platform} CFG_ARM64_core=y ${make_args[*]} &>>"${LOG_FILE}"
 }
 
 function build_uboot() {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -12,7 +12,7 @@ function read_config() {
         value=($(toml get common.${param} --toml-path ${config_file}))
     fi
 
-    echo "${value}"
+    echo "${value[*]}"
 }
 
 function read_machine_config() {


### PR DESCRIPTION
A config in toml can have multiple values, separated by space. The `read_config` function reads all of these space-separated values as individual strings in a `value` array. But then it returns only the first string by doing `echo ${value}`. Thus even if a config had multiple values, only the 1st gets returned.

This is usually not a problem since almost all of the configs so far have single-values. But in case of optee's make arguments, which are multiple, it returns only the 1st, and not the 2nd. Due to this, LPM doesn't work on am62pxx-evm, since the 2nd make argument is also necessary for making it work.

So return the entire array from `read_config`. And pass the entire array to optee's `make` command. This commit fixes LPM.