### PR TITLE
bdebstrap_configs: trixie: Set correct names for Linux debs

### DIFF
--- a/configs/bdebstrap_configs/trixie/trixie-am62lxx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62lxx-evm.yaml
@@ -34,8 +34,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-base
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
-    - linux-image-6.12.17-k3
-    - linux-headers-6.12.17-k3
+    - linux-image-6.12.17-00771-gc85877d40f8e
+    - linux-headers-6.12.17-00771-gc85877d40f8e
     - linux-libc-dev
     - libti-rpmsg-char
     - libti-rpmsg-char-dev

--- a/configs/bdebstrap_configs/trixie/trixie-am62pxx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62pxx-evm.yaml
@@ -36,8 +36,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3
-    - linux-headers-6.12.17-k3
+    - linux-image-6.12.17-00771-gc85877d40f8e
+    - linux-headers-6.12.17-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62p-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-am62xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62xx-evm.yaml
@@ -36,8 +36,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3
-    - linux-headers-6.12.17-k3
+    - linux-image-6.12.17-00771-gc85877d40f8e
+    - linux-headers-6.12.17-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-am62xx-lp-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62xx-lp-evm.yaml
@@ -37,8 +37,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3
-    - linux-headers-6.12.17-k3
+    - linux-image-6.12.17-00771-gc85877d40f8e
+    - linux-headers-6.12.17-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-am62xxsip-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am62xxsip-evm.yaml
@@ -37,8 +37,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3
-    - linux-headers-6.12.17-k3
+    - linux-image-6.12.17-00771-gc85877d40f8e
+    - linux-headers-6.12.17-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-am64xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-am64xx-evm.yaml
@@ -30,8 +30,8 @@ mmdebstrap:
     - vim
     - k3conf
     - weston
-    - linux-image-6.12.17-k3
-    - linux-headers-6.12.17-k3
+    - linux-image-6.12.17-00771-gc85877d40f8e
+    - linux-headers-6.12.17-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - firmware-ti-ipc-am64

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62lxx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62lxx-evm.yaml
@@ -34,8 +34,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-base
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
-    - linux-image-6.12.17-k3-rt
-    - linux-headers-6.12.17-k3-rt
+    - linux-image-6.12.17rt-00771-gc85877d40f8e
+    - linux-headers-6.12.17rt-00771-gc85877d40f8e
     - linux-libc-dev
     - libti-rpmsg-char
     - libti-rpmsg-char-dev

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62pxx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62pxx-evm.yaml
@@ -36,8 +36,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3-rt
-    - linux-headers-6.12.17-k3-rt
+    - linux-image-6.12.17rt-00771-gc85877d40f8e
+    - linux-headers-6.12.17rt-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62p-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-evm.yaml
@@ -36,8 +36,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3-rt
-    - linux-headers-6.12.17-k3-rt
+    - linux-image-6.12.17rt-00771-gc85877d40f8e
+    - linux-headers-6.12.17rt-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-lp-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62xx-lp-evm.yaml
@@ -37,8 +37,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3-rt
-    - linux-headers-6.12.17-k3-rt
+    - linux-image-6.12.17rt-00771-gc85877d40f8e
+    - linux-headers-6.12.17rt-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am62xxsip-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am62xxsip-evm.yaml
@@ -37,8 +37,8 @@ mmdebstrap:
     - gstreamer1.0-plugins-good
     - gstreamer1.0-plugins-bad
     - i2c-tools
-    - linux-image-6.12.17-k3-rt
-    - linux-headers-6.12.17-k3-rt
+    - linux-image-6.12.17rt-00771-gc85877d40f8e
+    - linux-headers-6.12.17rt-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - ti-img-rogue-driver-am62-dkms

--- a/configs/bdebstrap_configs/trixie/trixie-rt-am64xx-evm.yaml
+++ b/configs/bdebstrap_configs/trixie/trixie-rt-am64xx-evm.yaml
@@ -30,8 +30,8 @@ mmdebstrap:
     - vim
     - k3conf
     - weston
-    - linux-image-6.12.17-k3-rt
-    - linux-headers-6.12.17-k3-rt
+    - linux-image-6.12.17rt-00771-gc85877d40f8e
+    - linux-headers-6.12.17rt-00771-gc85877d40f8e
     - linux-libc-dev
     - cryptodev-linux-dkms
     - firmware-ti-ipc-am64


### PR DESCRIPTION
The names for linux debs do not match the ones in ti-debpkgs, so set this right.